### PR TITLE
Switch submodules to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "services"]
 	path = services
-	url = git@github.com:DoMo-98/ailab-services.git
+	url = https://github.com/DoMo-98/ailab-services.git
 [submodule "frontend"]
 	path = frontend
-	url = git@github.com:DoMo-98/ailab-frontend.git
+	url = https://github.com/DoMo-98/ailab-frontend.git


### PR DESCRIPTION
## Summary
- update `.gitmodules` to use HTTPS URLs for the frontend and services submodules

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841e2d1fa4c83238e6a18159045b9e6